### PR TITLE
Fix reactive property attribute

### DIFF
--- a/src/ReactiveObject.Generators.Tests/ReactivePropertyTests.cs
+++ b/src/ReactiveObject.Generators.Tests/ReactivePropertyTests.cs
@@ -21,7 +21,7 @@ using ReactiveObject.Generators;
 
 namespace MyTestNamespace
 {
-    public class MyTestClass
+    public partial class MyTestClass
     {
         [ReactiveProperty]
         private DateTime _dateTime;

--- a/src/ReactiveObject.Generators.Tests/ReactivePropertyTests.cs
+++ b/src/ReactiveObject.Generators.Tests/ReactivePropertyTests.cs
@@ -6,12 +6,6 @@ namespace ReactiveObject.Generators.Tests;
 public class ReactivePropertyTests
 {
     private const string _snapshotsDirectory = "Snapshots";
-    private readonly ITestOutputHelper _output;
-
-    public ReactivePropertyTests(ITestOutputHelper output)
-    {
-        _output = output;
-    }
 
     [Fact]
     public Task CanGenerateReactivePropertyInChildNamespace()

--- a/src/ReactiveObject.Generators/ReactivePropertyAttribute.cs
+++ b/src/ReactiveObject.Generators/ReactivePropertyAttribute.cs
@@ -3,9 +3,9 @@
     /// <summary>
     /// Add to property to indicate that extension methods should be generated for the type.
     /// </summary>
-    [System.AttributeUsage(System.AttributeTargets.Property)]
+    [System.AttributeUsage(System.AttributeTargets.Field)]
     [System.Diagnostics.Conditional("REACTIVEOBJECT_GENERATORS_USAGES")]
-    public class ReactivePropertyAttribute : System.Attribute
+    public sealed class ReactivePropertyAttribute : System.Attribute
     {
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
```[ReactiveProperty]``` according to test should be applicable to fields and not properties. This PR fixes it and a removes unused code in tests.


**What is the current behavior?**
```[ReactiveProperty]``` can be used on props.


**What is the new behavior?**
```[ReactiveProperty]``` is now usable on fields.


**What might this PR break?**


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

